### PR TITLE
Add plugin to pull solar information from Homeassistant

### DIFF
--- a/HOMEASSISTANT1.plugin.txt
+++ b/HOMEASSISTANT1.plugin.txt
@@ -1,33 +1,31 @@
 /////////             <version>1.0.0</version>
-/////////                     HOMEASSISTANT1                     ///////////////
+/////////                HOMEASSISTANT1                          ///////////////
 /////////  Plugin to extract Home Assistant Solar data for Toon  ///////////////
 /////////                   By Bonno                             ///////////////
-
-	function getSolarData(passWord,userName,apiKey,siteid,urlString,totalValue){
-		if (debugOutput) console.log("*********SolarPanel Start getHomeAssistantData")
-		var http = new XMLHttpRequest();
-		http.open("GET", "http://" + urlString + "/api/states/sensor.solar_panels", true)
-		http.setRequestHeader("Authorization: Bearer " + apiKey)
-		http.onreadystatechange = function() {
-			if (http.readyState == XMLHttpRequest.DONE) {
-				if (http.status === 200 || http.status === 300  || http.status === 302) {
-					try {
-						var JsonString = http.responseText
-						var JsonObject= JSON.parse(JsonString)
-						var currentPower = parseInt(JsonObject.attributes.current)
-                        var today2=parseInt(JsonObject.attributes.today)
-                        var totalValue= parseFloat(JsonObject.attributes.total)
-						parseReturnData(currentPower,totalValue,today2,0,0,0,0,http.status,"succes")
-					}
-					catch (e){
-						currentPower = 0
-						parseReturnData(0,totalValue,0,0,0,0,0, http.status,"error")
-					}
-				} else {
-					if (debugOutput) console.log("*********SolarPanel error: " + http.status)
-					parseReturnData(0,totalValue,0,0,0,0,0, http.status,"error")
-				}
-			}
-		}
-		http.send();
+function getSolarData(passWord, userName, apiKey, siteid, urlString, totalValue) {
+    if (debugOutput) console.log("*********SolarPanel Start getHomeAssistantData")
+    var http = new XMLHttpRequest();
+    http.open("GET", "http://" + urlString + "/api/states/sensor.solar_panel", true)
+    http.setRequestHeader("Authorization: Bearer " + apiKey)
+    http.onreadystatechange = function() {
+        if (http.readyState == XMLHttpRequest.DONE) {
+            if (http.status === 200 || http.status === 300 || http.status === 302) {
+                try {
+                    var JsonString = http.responseText
+                    var JsonObject = JSON.parse(JsonString)
+                    var currentPower = parseInt(JsonObject.attributes.current)
+                    var today2 = parseInt(JsonObject.attributes.today)
+                    var totalValue = parseFloat(JsonObject.attributes.total)
+                    parseReturnData(currentPower, totalValue, today2, 0, 0, 0, 0, http.status, "succes")
+                } catch (e) {
+                    currentPower = 0
+                    parseReturnData(0, totalValue, 0, 0, 0, 0, 0, http.status, "error")
+                }
+            } else {
+                if (debugOutput) console.log("*********SolarPanel error: " + http.status)
+                parseReturnData(0, totalValue, 0, 0, 0, 0, 0, http.status, "error")
+            }
+        }
     }
+    http.send();
+}

--- a/HOMEASSISTANT1.plugin.txt
+++ b/HOMEASSISTANT1.plugin.txt
@@ -1,0 +1,33 @@
+/////////             <version>1.0.0</version>
+/////////                     HOMEASSISTANT1                     ///////////////
+/////////  Plugin to extract Home Assistant Solar data for Toon  ///////////////
+/////////                   By Bonno                             ///////////////
+
+	function getSolarData(passWord,userName,apiKey,siteid,urlString,totalValue){
+		if (debugOutput) console.log("*********SolarPanel Start getHomeAssistantData")
+		var http = new XMLHttpRequest();
+		http.open("GET", "http://" + urlString + "/api/states/sensor.solar_panels", true)
+		http.setRequestHeader("Authorization: Bearer " + apiKey)
+		http.onreadystatechange = function() {
+			if (http.readyState == XMLHttpRequest.DONE) {
+				if (http.status === 200 || http.status === 300  || http.status === 302) {
+					try {
+						var JsonString = http.responseText
+						var JsonObject= JSON.parse(JsonString)
+						var currentPower = parseInt(JsonObject.attributes.current)
+                        var today2=parseInt(JsonObject.attributes.today)
+                        var totalValue= parseFloat(JsonObject.attributes.total)
+						parseReturnData(currentPower,totalValue,today2,0,0,0,0,http.status,"succes")
+					}
+					catch (e){
+						currentPower = 0
+						parseReturnData(0,totalValue,0,0,0,0,0, http.status,"error")
+					}
+				} else {
+					if (debugOutput) console.log("*********SolarPanel error: " + http.status)
+					parseReturnData(0,totalValue,0,0,0,0,0, http.status,"error")
+				}
+			}
+		}
+		http.send();
+    }

--- a/HOMEASSISTANT1.plugin.txt
+++ b/HOMEASSISTANT1.plugin.txt
@@ -1,32 +1,30 @@
-/////////             <version>1.0.0</version>
-/////////                HOMEASSISTANT1                          ///////////////
-/////////  Plugin to extract Home Assistant Solar data for Toon  ///////////////
-/////////                   By Bonno                             ///////////////
-function getSolarData(passWord, userName, apiKey, siteid, urlString, totalValue) {
+/////////                <version>1.0.1</version>                /////////
+/////////                     HOMEASSISTANT1                     /////////
+/////////  Plugin to extract Home Assistant Solar data for Toon  /////////
+/////////                        By Bonno                        /////////
+function getSolarData(password, username, apiKey, siteId, urlString, totalPower) {
     if (debugOutput) console.log("*********SolarPanel Start getHomeAssistantData")
     var url = "http://" + urlString + "/api/states/sensor.solar_panel"
     var http = new XMLHttpRequest();
     if (debugOutput) console.log("*********SolarPanel HA url " + url) 
-    if (debugOutput) console.log("*********SolarPanel HA token " + apiKey)
     http.open("GET", url, true)
     http.setRequestHeader("Authorization", "Bearer " + apiKey);
     http.onreadystatechange = function() {
         if (http.readyState == XMLHttpRequest.DONE) {
             if (http.status === 200 || http.status === 300 || http.status === 302) {
                 try {
-                    var JsonString = http.responseText
-                    var JsonObject = JSON.parse(JsonString)
-                    var currentPower = parseInt(JsonObject.attributes.current)
-                    var today2 = parseInt(JsonObject.attributes.today)
-                    var totalValue = parseFloat(JsonObject.attributes.total)
-                    parseReturnData(currentPower, totalValue, today2, 0, 0, 0, 0, http.status, "succes")
+                    var sensorResult = http.responseText
+                    var sensorObject = JSON.parse(sensorResult)
+                    var currentPower = parseInt(sensorObject.attributes.current)
+                    var todayPower = parseInt(sensorObject.attributes.today)
+                    var totalPower = parseFloat(sensorObject.attributes.total)
+                    parseReturnData(currentPower, totalPower, todayPower, 0, 0, 0, 0, http.status, "succes")
                 } catch (e) {
-                    currentPower = 0
-                    parseReturnData(0, totalValue, 0, 0, 0, 0, 0, http.status, "error")
+                    parseReturnData(0, totalPower, 0, 0, 0, 0, 0, http.status, "error")
                 }
             } else {
                 if (debugOutput) console.log("*********SolarPanel error: " + http.status)
-                parseReturnData(0, totalValue, 0, 0, 0, 0, 0, http.status, "error")
+                parseReturnData(0, totalPower, 0, 0, 0, 0, 0, http.status, "error")
             }
         }
     }

--- a/HOMEASSISTANT1.plugin.txt
+++ b/HOMEASSISTANT1.plugin.txt
@@ -4,9 +4,12 @@
 /////////                   By Bonno                             ///////////////
 function getSolarData(passWord, userName, apiKey, siteid, urlString, totalValue) {
     if (debugOutput) console.log("*********SolarPanel Start getHomeAssistantData")
+    var url = "http://" + urlString + "/api/states/sensor.solar_panel"
     var http = new XMLHttpRequest();
-    http.open("GET", "http://" + urlString + "/api/states/sensor.solar_panel", true)
-    http.setRequestHeader("Authorization: Bearer " + apiKey)
+    if (debugOutput) console.log("*********SolarPanel HA url " + url) 
+    if (debugOutput) console.log("*********SolarPanel HA token " + apiKey)
+    http.open("GET", url, true)
+    http.setRequestHeader("Authorization", "Bearer " + apiKey);
     http.onreadystatechange = function() {
         if (http.readyState == XMLHttpRequest.DONE) {
             if (http.status === 200 || http.status === 300 || http.status === 302) {

--- a/README.HOMEASSISTANT1.md
+++ b/README.HOMEASSISTANT1.md
@@ -1,0 +1,100 @@
+# Home Assistant sensor
+
+De home assistant plugin leest een sensor met de naam 'solar_panel' uit. Deze sensor dien je zelf te definieren in een sensor template. Zie hieronder voor een voorbeeld. 
+
+### Sensor template
+    - sensor:
+        - name: "Solar panel"
+          unique_id: 36164133-d6cb-4d56-9c8b-38c634fc2c5f
+          state: >
+            {% if states.sensor.growatt_total_energy_lifetime is defined and states.sensor.growatt_total_energy_lifetime.state not in ['unavailable', 'none', 'unknown', '0'] %}
+                {{ (states.sensor.growatt_total_energy_lifetime.state | float(0)) * 1000 }}
+            {% else %}
+                {{ states.input_number.solar_panels_total_lifetime_wh.state | float }}
+            {% endif %}
+          icon: >
+            mdi:solar-power
+          attributes:
+            current: >
+              {% if states.sensor.growatt_total_power is defined %}
+                  {{ states.sensor.growatt_total_power.state | float(0) }}
+              {% else %}
+                  'unavailable'
+              {% endif %}
+            today: >
+              {% if states.sensor.growatt_total_energy_today is defined and states.sensor.growatt_total_energy_today.state not in ['unavailable', 'none', 'unknown', '0'] %}
+                  {{ ( states.sensor.growatt_total_energy_today.state | float(0)) * 1000 }}
+              {% elif states.sensor.growatt_total_energy_today is defined and states.sensor.growatt_total_energy_today.state in ['unavailable', 'none', 'unknown', '0'] %}
+                  {{ states.input_number.solar_panels_today_wh.state | float }}
+              {% else %}
+                  'unavailable'
+              {% endif %}
+            total: >
+              {{ states.sensor.solar_panel.state }}
+
+
+### Automation
+Ik maak gebruik van een ESPHome dongle in mijn growatt inverter die de data direct naar mijn home assistant server stuurt, maar deze dongle raakt 'unavailale' wanneer de inverter uitstaat (wanneer de zon niet (meer) schijnt). Hierdoor zou de data die Toon ophaalt regelmatig leeg kunnen zijn. Daarom maak ik gebruik van 2 input_number helpers: 'input_number.solar_panels_total_lifetime_wh' en 'input_number.solar_panels_today_wh'. Deze worden door een automation gevuld.
+
+    alias: "Systeem: Solar panels"
+    description: ""
+    trigger:
+      - platform: state
+        entity_id:
+          - sensor.growatt_total_energy_lifetime
+        id: lifetime
+      - platform: state
+        entity_id:
+          - sensor.growatt_total_energy_today
+        id: today
+    condition:
+      - condition: or
+        conditions:
+          - condition: and
+            conditions:
+              - condition: not
+                conditions:
+                  - condition: state
+                    entity_id: sensor.growatt_total_energy_lifetime
+                    state: unavailable
+              - condition: not
+                conditions:
+                  - condition: state
+                    entity_id: sensor.growatt_total_energy_lifetime
+                    state: unknown
+          - condition: and
+            conditions:
+              - condition: not
+                conditions:
+                  - condition: state
+                    entity_id: sensor.growatt_total_energy_today
+                    state: unavailable
+              - condition: not
+                conditions:
+                  - condition: state
+                    entity_id: sensor.growatt_total_energy_today
+                    state: unknown
+    action:
+      - if:
+          - condition: trigger
+            id: lifetime
+        then:
+          - service: input_number.set_value
+            data:
+              value: >-
+                {{ (states.sensor.growatt_total_energy_lifetime.state | float(0)) * 1000 }}
+            target:
+              entity_id: input_number.solar_panels_total_lifetime_wh
+      - if:
+          - condition: trigger
+            id: today
+        then:
+          - service: input_number.set_value
+            data:
+              value: >-
+                {{ ( states.sensor.growatt_total_energy_today.state | float(0)) * 1000 }}
+            target:
+              entity_id: input_number.solar_panels_today_wh
+    mode: single
+
+

--- a/inverters.json
+++ b/inverters.json
@@ -9,7 +9,7 @@
 			{"friendlyName":"Goodwe", "filename":"GOODWE1", "data": ["Username","Password"], "info":"Plugin voor Goodwe omvormers via het portal"},
 			{"friendlyName":"Goodwe2", "filename":"GOODWE2", "data": ["Username","Password","SiteID"], "info":"Plugin voor Goodwe omvormers via het portal. Deze gebruiken als je wilt selecteren op naam van de installtie. Vul de naam in bij siteId."},
 			{"friendlyName":"Growatt", "filename":"GROW1", "data": ["Username","Password"], "info":"Plugin voor Growatt omvormers via het portal"},
-			{"friendlyName":"Home Assistant", "filename":"HOMEASSISTANT1", "data": ["URL","APIKey"], "info":"Plugin voor Home Assistant. Zie README.homeassist.md voor sensor specificaties.Geef ip incl Port als 192.168.1.1:8123"},
+			{"friendlyName":"Home Assistant", "filename":"HOMEASSISTANT1", "data": ["URL","APIKey"], "info":"Plugin voor Home Assistant. Zie README.HOMEASSISTANT1.md voor sensor specificaties.Geef ip incl Port als 192.168.1.1:8123"},
 			{"friendlyName":"Hoymiles", "filename":"HOY1", "data": ["SiteID","Username","Password"], "info":"Plugin voor Hoymiles omvormers via het portal. SiteId wordt gevonden door bovenin het schem in de url tekijken als je bent ingelogd."},
 			{"friendlyName":"Kostal Piko", "filename":"KOSTAL1", "data": ["URL"], "info":"Plugin voor Kostal omvormers. (lokaal)"},
 			{"friendlyName":"Omnik", "filename":"OMNIK1", "data": ["Username","Password"], "info":"Deze plugin maakt gebruik van het Omnik Portal. Soms gaat het portal de fout in met de dagwaarden."},

--- a/inverters.json
+++ b/inverters.json
@@ -9,6 +9,7 @@
 			{"friendlyName":"Goodwe", "filename":"GOODWE1", "data": ["Username","Password"], "info":"Plugin voor Goodwe omvormers via het portal"},
 			{"friendlyName":"Goodwe2", "filename":"GOODWE2", "data": ["Username","Password","SiteID"], "info":"Plugin voor Goodwe omvormers via het portal. Deze gebruiken als je wilt selecteren op naam van de installtie. Vul de naam in bij siteId."},
 			{"friendlyName":"Growatt", "filename":"GROW1", "data": ["Username","Password"], "info":"Plugin voor Growatt omvormers via het portal"},
+			{"friendlyName":"Home Assistant", "filename":"HOMEASSISTANT1", "data": ["URL","APIKey"], "info":"Plugin voor Home Assistant. Zie README.homeassist.md voor sensor specificaties.Geef ip incl Port als 192.168.1.1:8123"},
 			{"friendlyName":"Hoymiles", "filename":"HOY1", "data": ["SiteID","Username","Password"], "info":"Plugin voor Hoymiles omvormers via het portal. SiteId wordt gevonden door bovenin het schem in de url tekijken als je bent ingelogd."},
 			{"friendlyName":"Kostal Piko", "filename":"KOSTAL1", "data": ["URL"], "info":"Plugin voor Kostal omvormers. (lokaal)"},
 			{"friendlyName":"Omnik", "filename":"OMNIK1", "data": ["Username","Password"], "info":"Deze plugin maakt gebruik van het Omnik Portal. Soms gaat het portal de fout in met de dagwaarden."},


### PR DESCRIPTION
I have added a plugin to pull the solar information from home assistant. This is done via a generic sensor template. This way the user can customize their solar data in their own way as long as the sensor for Toon is compatible with this plugin. I've added a README file with more information for the home assistant users.